### PR TITLE
Fix collect logs playbook and minor improvement to the monitoring playbook

### DIFF
--- a/ansible-control-host-docker/Dockerfile
+++ b/ansible-control-host-docker/Dockerfile
@@ -18,16 +18,11 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367 &&
     apt-get install python-jmespath && \
     apt-get autoremove && apt-get autoclean
 
-RUN ansible-galaxy collection install community.docker:3.0.2
-RUN ansible-galaxy collection install community.general:4.8.6
-
 # create ubuntu user
 RUN useradd -ms /bin/bash ubuntu
 RUN usermod -aG sudo ubuntu
 USER ubuntu
 WORKDIR /home/ubuntu/
-
-RUN mkdir zdm-proxy-ssh-key-dir/
 
 USER root
 RUN echo 'ubuntu ALL=NOPASSWD: ALL' >> /etc/sudoers
@@ -43,7 +38,11 @@ RUN chmod +x init_container_internal.sh
 
 USER ubuntu
 
+RUN ansible-galaxy collection install community.docker:3.0.2
+RUN ansible-galaxy collection install community.general:4.8.6
+
 RUN cd
+RUN mkdir zdm-proxy-ssh-key-dir
 RUN mkdir origin_tls_files
 RUN mkdir target_tls_files
 RUN mkdir zdm_proxy_tls_files

--- a/ansible/collect_zdm_proxy_logs.yml
+++ b/ansible/collect_zdm_proxy_logs.yml
@@ -1,19 +1,22 @@
 ---
 - name: Create log collection directories on the control host
-  hosts: "{{ log_collection_playbook_host }}"
+  host: localhost
   vars_files:
     - vars/zdm_proxy_log_collection_config.yml
     - vars/zdm_playbook_internal_config.yml
 
   tasks:
     - name: Create log archive directory
+      #delegate_to: localhost
       file:
-        path: "{{ control_host_home_dir }}/{{ archived_log_dir_name }}/"
+        path: "/home/ubuntu/{{ archived_log_dir_name }}/"
         state: directory
     - name: Create temporary log collection directory
+      #delegate_to: localhost
       file:
-        path: "{{ control_host_home_dir }}/{{ host_tmp_log_dir_name }}/"
+        path: "/home/ubuntu/{{ tmp_log_dir_name }}/"
         state: directory
+
 
 - name: Collect all ZDM proxy logs
   hosts: proxies
@@ -39,25 +42,26 @@
     - name: Fetch the logs of the container, copying them to the temporary log collection directory in the control host container
       fetch:
         src: "{{ item.path }}"
-        dest: "{{ control_host_home_dir }}/{{ container_tmp_log_dir_name }}/"
+        dest: "/home/ubuntu/{{ tmp_log_dir_name }}/"
         flat: yes
       with_items: "{{ logfilenames.files }}"
-    - name: Copy files from the temporary log collection directory in the control host container to the one on the host
-      command: "docker cp zdm-ansible-container:/home/ubuntu/cont_tmp_logs/. /home/ubuntu/host_tmp_logs/"
-#
-#- name: Zip the logs in a single archive
-#  hosts: "{{ log_collection_playbook_host }}"
-#  vars_files:
-#    - vars/zdm_proxy_log_collection_config.yml
-#    - vars/zdm_playbook_internal_config.yml
-#
-#  tasks:
-#    - name: Create the zip archive
-#      community.general.archive:
-#        path: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
-#        dest: "{{ control_host_home_dir }}/{{ archived_log_dir_name }}/zdm_proxy_logs_{{ ansible_date_time.iso8601_basic_short }}.zip"
-#        format: zip
-#    - name: Remove the temporary directory where the logs were copied on the control host
-#      file:
-#        path: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
-#        state: absent
+
+
+- name: Zip the logs in a single archive
+  hosts: localhost
+  vars_files:
+    - vars/zdm_proxy_log_collection_config.yml
+    - vars/zdm_playbook_internal_config.yml
+
+  tasks:
+    - name: Create the zip archive
+      #delegate_to: localhost
+      community.general.archive:
+        path: "/home/ubuntu/{{ tmp_log_dir_name }}/"
+        dest: "/home/ubuntu/{{ archived_log_dir_name }}/zdm_proxy_logs_{{ ansible_date_time.iso8601_basic_short }}.zip"
+        format: zip
+    - name: Remove the temporary directory where the logs were copied on the control host
+      #delegate_to: localhost
+      file:
+        path: "/home/ubuntu/{{ tmp_log_dir_name }}/"
+        state: absent

--- a/ansible/collect_zdm_proxy_logs.yml
+++ b/ansible/collect_zdm_proxy_logs.yml
@@ -53,7 +53,7 @@
       register: logfilenames
       when:
         - containerinfo is defined
-    - name: Fetch the logs of the container, copying them to the temporary log collection direcotry on the control host
+    - name: Fetch the logs of the container, copying them to the temporary log collection directory on the control host
       fetch:
         src: "{{ item.path }}"
         dest: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
@@ -70,9 +70,10 @@
     - name: Create the zip archive
       community.general.archive:
         path: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
-        dest: "{{ control_host_home_dir }}/{{ archived_log_dir_name }}/zdm_proxy_logs_{{ ansible_date_time.iso8601_basic_short }}.zip"
+        #dest: "{{ control_host_home_dir }}/{{ archived_log_dir_name }}/zdm_proxy_logs_{{ ansible_date_time.iso8601_basic_short }}.zip"
+        dest: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/zdm_proxy_logs_{{ ansible_date_time.iso8601_basic_short }}.zip"
         format: zip
-    - name: Remove the temporary directory where the logs were copied on the control host
-      file:
-        path: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
-        state: absent
+#    - name: Remove the temporary directory where the logs were copied on the control host
+#      file:
+#        path: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
+#        state: absent

--- a/ansible/collect_zdm_proxy_logs.yml
+++ b/ansible/collect_zdm_proxy_logs.yml
@@ -1,4 +1,20 @@
 ---
+- name: Create log collection directories on the control host
+  hosts: "{{ log_collection_playbook_host }}"
+  vars_files:
+    - vars/zdm_proxy_log_collection_config.yml
+    - vars/zdm_playbook_internal_config.yml
+
+  tasks:
+    - name: Create temporary log collection directory
+      file:
+        path: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
+        state: directory
+    - name: Create log archive directory
+      file:
+        path: "{{ control_host_home_dir }}/{{ archived_log_dir_name }}/"
+        state: directory
+
 - name: Collect all ZDM proxy logs
   hosts: proxies
   become: yes
@@ -20,14 +36,10 @@
       register: logfilenames
       when:
         - containerinfo is defined
-    - name: Create temporary directory
-      file:
-        path: "{{ zdm_proxy_home_dir }}/{{ tmp_log_dir_name }}/"
-        state: directory
-    - name: Fetch the logs of the container
+    - name: Fetch the logs of the container, copying them to the temporary log collection direcotry on the control host
       fetch:
         src: "{{ item.path }}"
-        dest: "{{ zdm_proxy_home_dir }}/{{ tmp_log_dir_name }}/"
+        dest: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
         flat: yes
       with_items: "{{ logfilenames.files }}"
 
@@ -38,28 +50,12 @@
     - vars/zdm_playbook_internal_config.yml
 
   tasks:
-    - name: Create general log archive directory if it doesn't exist
-      file:
-        path: "{{ zdm_proxy_home_dir }}/{{ archived_log_dir_name }}/"
-        state: directory
-    - name: Zip the logs in a single archive
+    - name: Create the zip archive
       community.general.archive:
-        path: "{{ zdm_proxy_home_dir }}/{{ tmp_log_dir_name }}/"
-        dest: "{{ zdm_proxy_home_dir }}/{{ archived_log_dir_name }}/zdm_proxy_logs_{{ ansible_date_time.iso8601_basic_short }}.zip"
+        path: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
+        dest: "{{ control_host_home_dir }}/{{ archived_log_dir_name }}/zdm_proxy_logs_{{ ansible_date_time.iso8601_basic_short }}.zip"
         format: zip
     - name: Remove the temporary directory where the logs were copied on the control host
       file:
-        path: "{{ zdm_proxy_home_dir }}/{{ tmp_log_dir_name }}/"
-        state: absent
-
-- name: Remove the temporary directory from all proxies
-  hosts: proxies
-  vars_files:
-    - vars/zdm_proxy_log_collection_config.yml
-    - vars/zdm_playbook_internal_config.yml
-
-  tasks:
-    - name: Remove the temporary directories where the logs were copied on each proxy host
-      file:
-        path: "{{ zdm_proxy_home_dir }}/{{ tmp_log_dir_name }}/"
+        path: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
         state: absent

--- a/ansible/collect_zdm_proxy_logs.yml
+++ b/ansible/collect_zdm_proxy_logs.yml
@@ -1,19 +1,36 @@
 ---
-- name: Create log collection directories on the control host
+- name: Create log collection directories on the control host (tmp)
   hosts: "{{ log_collection_playbook_host }}"
   vars_files:
     - vars/zdm_proxy_log_collection_config.yml
     - vars/zdm_playbook_internal_config.yml
 
   tasks:
+#    - name: Create log archive directory
+#      file:
+#        path: "{{ control_host_home_dir }}/{{ archived_log_dir_name }}/"
+#        state: directory
     - name: Create temporary log collection directory
       file:
         path: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
         state: directory
+
+- name: Create log collection directories on the control host (archive)
+  hosts: "{{ log_collection_playbook_host }}"
+  vars_files:
+    - vars/zdm_proxy_log_collection_config.yml
+    - vars/zdm_playbook_internal_config.yml
+
+  tasks:
     - name: Create log archive directory
       file:
         path: "{{ control_host_home_dir }}/{{ archived_log_dir_name }}/"
         state: directory
+#    - name: Create temporary log collection directory
+#      file:
+#        path: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
+#        state: directory
+
 
 - name: Collect all ZDM proxy logs
   hosts: proxies

--- a/ansible/collect_zdm_proxy_logs.yml
+++ b/ansible/collect_zdm_proxy_logs.yml
@@ -2,7 +2,6 @@
 - name: Create log collection directories on the control host
   hosts: localhost
   vars_files:
-    - vars/zdm_proxy_log_collection_config.yml
     - vars/zdm_playbook_internal_config.yml
 
   tasks:
@@ -21,7 +20,6 @@
   become: yes
   vars_files:
     - vars/zdm_proxy_container_config.yml
-    - vars/zdm_proxy_log_collection_config.yml
     - vars/zdm_playbook_internal_config.yml
 
   tasks:
@@ -48,7 +46,6 @@
 - name: Zip the logs in a single archive
   hosts: localhost
   vars_files:
-    - vars/zdm_proxy_log_collection_config.yml
     - vars/zdm_playbook_internal_config.yml
 
   tasks:

--- a/ansible/collect_zdm_proxy_logs.yml
+++ b/ansible/collect_zdm_proxy_logs.yml
@@ -47,6 +47,10 @@
         path: "{{ zdm_proxy_home_dir }}/{{ tmp_log_dir_name }}/"
         dest: "{{ zdm_proxy_home_dir }}/{{ archived_log_dir_name }}/zdm_proxy_logs_{{ ansible_date_time.iso8601_basic_short }}.zip"
         format: zip
+    - name: Remove the temporary directory where the logs were copied on the control host
+      file:
+        path: "{{ zdm_proxy_home_dir }}/{{ tmp_log_dir_name }}/"
+        state: absent
 
 - name: Remove the temporary directory from all proxies
   hosts: proxies
@@ -55,7 +59,7 @@
     - vars/zdm_playbook_internal_config.yml
 
   tasks:
-    - name: Remove the temporary directory where the logs were copied
+    - name: Remove the temporary directories where the logs were copied on each proxy host
       file:
         path: "{{ zdm_proxy_home_dir }}/{{ tmp_log_dir_name }}/"
         state: absent

--- a/ansible/collect_zdm_proxy_logs.yml
+++ b/ansible/collect_zdm_proxy_logs.yml
@@ -10,10 +10,10 @@
 #      file:
 #        path: "{{ control_host_home_dir }}/{{ archived_log_dir_name }}/"
 #        state: directory
-    - name: Create temporary log collection directory
-      file:
-        path: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
-        state: directory
+#    - name: Create temporary log collection directory
+#      file:
+#        path: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
+#        state: directory
 
 - name: Create log collection directories on the control host (archive)
   hosts: "{{ log_collection_playbook_host }}"

--- a/ansible/collect_zdm_proxy_logs.yml
+++ b/ansible/collect_zdm_proxy_logs.yml
@@ -7,12 +7,10 @@
 
   tasks:
     - name: Create log archive directory
-      #delegate_to: localhost
       file:
         path: "/home/ubuntu/{{ archived_log_dir_name }}/"
         state: directory
     - name: Create temporary log collection directory
-      #delegate_to: localhost
       file:
         path: "/home/ubuntu/{{ tmp_log_dir_name }}/"
         state: directory
@@ -39,7 +37,7 @@
       register: logfilenames
       when:
         - containerinfo is defined
-    - name: Fetch the logs of the container, copying them to the temporary log collection directory in the control host container
+    - name: Fetch the proxy logs, copying them to the temporary log collection directory in the control host container
       fetch:
         src: "{{ item.path }}"
         dest: "/home/ubuntu/{{ tmp_log_dir_name }}/"
@@ -55,13 +53,11 @@
 
   tasks:
     - name: Create the zip archive
-      #delegate_to: localhost
       community.general.archive:
         path: "/home/ubuntu/{{ tmp_log_dir_name }}/"
         dest: "/home/ubuntu/{{ archived_log_dir_name }}/zdm_proxy_logs_{{ ansible_date_time.iso8601_basic_short }}.zip"
         format: zip
     - name: Remove the temporary directory where the logs were copied on the control host
-      #delegate_to: localhost
       file:
         path: "/home/ubuntu/{{ tmp_log_dir_name }}/"
         state: absent

--- a/ansible/collect_zdm_proxy_logs.yml
+++ b/ansible/collect_zdm_proxy_logs.yml
@@ -4,8 +4,6 @@
   vars_files:
     - vars/zdm_proxy_log_collection_config.yml
     - vars/zdm_playbook_internal_config.yml
-  vars:
-    ansible_connection: docker
 
   tasks:
     - name: Create log archive directory
@@ -17,49 +15,47 @@
         path: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
         state: directory
 
-- name: Collect all ZDM proxy logs
-  hosts: proxies
-  become: yes
-  vars_files:
-    - vars/zdm_proxy_container_config.yml
-    - vars/zdm_proxy_log_collection_config.yml
-    - vars/zdm_playbook_internal_config.yml
-
-  tasks:
-    - name: Inspect the ZDM proxy container
-      docker_container_info:
-        name: "{{ zdm_proxy_container_name }}"
-      register: containerinfo
-    - name: Find the log files to copy/fetch
-      find:
-        paths: "/var/lib/docker/containers/{{ containerinfo.container.Id }}"
-        patterns: ".*-json.log$"
-        use_regex: yes
-      register: logfilenames
-      when:
-        - containerinfo is defined
-    - name: Fetch the logs of the container, copying them to the temporary log collection directory on the control host
-      fetch:
-        src: "{{ item.path }}"
-        dest: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
-        flat: yes
-      with_items: "{{ logfilenames.files }}"
-
-- name: Zip the logs in a single archive
-  hosts: "{{ log_collection_playbook_host }}"
-  vars_files:
-    - vars/zdm_proxy_log_collection_config.yml
-    - vars/zdm_playbook_internal_config.yml
-  vars:
-    ansible_connection: docker
-
-  tasks:
-    - name: Create the zip archive
-      community.general.archive:
-        path: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
-        dest: "{{ control_host_home_dir }}/{{ archived_log_dir_name }}/zdm_proxy_logs_{{ ansible_date_time.iso8601_basic_short }}.zip"
-        format: zip
-    - name: Remove the temporary directory where the logs were copied on the control host
-      file:
-        path: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
-        state: absent
+#- name: Collect all ZDM proxy logs
+#  hosts: proxies
+#  become: yes
+#  vars_files:
+#    - vars/zdm_proxy_container_config.yml
+#    - vars/zdm_proxy_log_collection_config.yml
+#    - vars/zdm_playbook_internal_config.yml
+#
+#  tasks:
+#    - name: Inspect the ZDM proxy container
+#      docker_container_info:
+#        name: "{{ zdm_proxy_container_name }}"
+#      register: containerinfo
+#    - name: Find the log files to copy/fetch
+#      find:
+#        paths: "/var/lib/docker/containers/{{ containerinfo.container.Id }}"
+#        patterns: ".*-json.log$"
+#        use_regex: yes
+#      register: logfilenames
+#      when:
+#        - containerinfo is defined
+#    - name: Fetch the logs of the container, copying them to the temporary log collection directory on the control host
+#      fetch:
+#        src: "{{ item.path }}"
+#        dest: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
+#        flat: yes
+#      with_items: "{{ logfilenames.files }}"
+#
+#- name: Zip the logs in a single archive
+#  hosts: "{{ log_collection_playbook_host }}"
+#  vars_files:
+#    - vars/zdm_proxy_log_collection_config.yml
+#    - vars/zdm_playbook_internal_config.yml
+#
+#  tasks:
+#    - name: Create the zip archive
+#      community.general.archive:
+#        path: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
+#        dest: "{{ control_host_home_dir }}/{{ archived_log_dir_name }}/zdm_proxy_logs_{{ ansible_date_time.iso8601_basic_short }}.zip"
+#        format: zip
+#    - name: Remove the temporary directory where the logs were copied on the control host
+#      file:
+#        path: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
+#        state: absent

--- a/ansible/collect_zdm_proxy_logs.yml
+++ b/ansible/collect_zdm_proxy_logs.yml
@@ -1,36 +1,21 @@
 ---
-- name: Create log collection directories on the control host (tmp)
+- name: Create log collection directories on the control host
   hosts: "{{ log_collection_playbook_host }}"
   vars_files:
     - vars/zdm_proxy_log_collection_config.yml
     - vars/zdm_playbook_internal_config.yml
-
-  tasks:
-#    - name: Create log archive directory
-#      file:
-#        path: "{{ control_host_home_dir }}/{{ archived_log_dir_name }}/"
-#        state: directory
-#    - name: Create temporary log collection directory
-#      file:
-#        path: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
-#        state: directory
-
-- name: Create log collection directories on the control host (archive)
-  hosts: "{{ log_collection_playbook_host }}"
-  vars_files:
-    - vars/zdm_proxy_log_collection_config.yml
-    - vars/zdm_playbook_internal_config.yml
+  vars:
+    ansible_connection: docker
 
   tasks:
     - name: Create log archive directory
       file:
         path: "{{ control_host_home_dir }}/{{ archived_log_dir_name }}/"
         state: directory
-#    - name: Create temporary log collection directory
-#      file:
-#        path: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
-#        state: directory
-
+    - name: Create temporary log collection directory
+      file:
+        path: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
+        state: directory
 
 - name: Collect all ZDM proxy logs
   hosts: proxies
@@ -65,15 +50,16 @@
   vars_files:
     - vars/zdm_proxy_log_collection_config.yml
     - vars/zdm_playbook_internal_config.yml
+  vars:
+    ansible_connection: docker
 
   tasks:
     - name: Create the zip archive
       community.general.archive:
         path: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
-        #dest: "{{ control_host_home_dir }}/{{ archived_log_dir_name }}/zdm_proxy_logs_{{ ansible_date_time.iso8601_basic_short }}.zip"
-        dest: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/zdm_proxy_logs_{{ ansible_date_time.iso8601_basic_short }}.zip"
+        dest: "{{ control_host_home_dir }}/{{ archived_log_dir_name }}/zdm_proxy_logs_{{ ansible_date_time.iso8601_basic_short }}.zip"
         format: zip
-#    - name: Remove the temporary directory where the logs were copied on the control host
-#      file:
-#        path: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
-#        state: absent
+    - name: Remove the temporary directory where the logs were copied on the control host
+      file:
+        path: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
+        state: absent

--- a/ansible/collect_zdm_proxy_logs.yml
+++ b/ansible/collect_zdm_proxy_logs.yml
@@ -12,36 +12,38 @@
         state: directory
     - name: Create temporary log collection directory
       file:
-        path: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
+        path: "{{ control_host_home_dir }}/{{ host_tmp_log_dir_name }}/"
         state: directory
 
-#- name: Collect all ZDM proxy logs
-#  hosts: proxies
-#  become: yes
-#  vars_files:
-#    - vars/zdm_proxy_container_config.yml
-#    - vars/zdm_proxy_log_collection_config.yml
-#    - vars/zdm_playbook_internal_config.yml
-#
-#  tasks:
-#    - name: Inspect the ZDM proxy container
-#      docker_container_info:
-#        name: "{{ zdm_proxy_container_name }}"
-#      register: containerinfo
-#    - name: Find the log files to copy/fetch
-#      find:
-#        paths: "/var/lib/docker/containers/{{ containerinfo.container.Id }}"
-#        patterns: ".*-json.log$"
-#        use_regex: yes
-#      register: logfilenames
-#      when:
-#        - containerinfo is defined
-#    - name: Fetch the logs of the container, copying them to the temporary log collection directory on the control host
-#      fetch:
-#        src: "{{ item.path }}"
-#        dest: "{{ control_host_home_dir }}/{{ tmp_log_dir_name }}/"
-#        flat: yes
-#      with_items: "{{ logfilenames.files }}"
+- name: Collect all ZDM proxy logs
+  hosts: proxies
+  become: yes
+  vars_files:
+    - vars/zdm_proxy_container_config.yml
+    - vars/zdm_proxy_log_collection_config.yml
+    - vars/zdm_playbook_internal_config.yml
+
+  tasks:
+    - name: Inspect the ZDM proxy container
+      docker_container_info:
+        name: "{{ zdm_proxy_container_name }}"
+      register: containerinfo
+    - name: Find the log files to copy/fetch
+      find:
+        paths: "/var/lib/docker/containers/{{ containerinfo.container.Id }}"
+        patterns: ".*-json.log$"
+        use_regex: yes
+      register: logfilenames
+      when:
+        - containerinfo is defined
+    - name: Fetch the logs of the container, copying them to the temporary log collection directory in the control host container
+      fetch:
+        src: "{{ item.path }}"
+        dest: "{{ control_host_home_dir }}/{{ container_tmp_log_dir_name }}/"
+        flat: yes
+      with_items: "{{ logfilenames.files }}"
+    - name: Copy files from the temporary log collection directory in the control host container to the one on the host
+      command: "docker cp zdm-ansible-container:/home/ubuntu/cont_tmp_logs/. /home/ubuntu/host_tmp_logs/"
 #
 #- name: Zip the logs in a single archive
 #  hosts: "{{ log_collection_playbook_host }}"

--- a/ansible/collect_zdm_proxy_logs.yml
+++ b/ansible/collect_zdm_proxy_logs.yml
@@ -1,6 +1,6 @@
 ---
 - name: Create log collection directories on the control host
-  host: localhost
+  hosts: localhost
   vars_files:
     - vars/zdm_proxy_log_collection_config.yml
     - vars/zdm_playbook_internal_config.yml

--- a/ansible/deploy_zdm_monitoring.yml
+++ b/ansible/deploy_zdm_monitoring.yml
@@ -41,7 +41,7 @@
 
 - name: Install Docker on the monitoring server
   hosts: monitoring
-  #become: yes
+  become: yes
   vars_files:
     - vars/zdm_playbook_internal_config.yml
 

--- a/ansible/deploy_zdm_monitoring.yml
+++ b/ansible/deploy_zdm_monitoring.yml
@@ -1,7 +1,7 @@
 ---
 - name: Deploy a Prometheus Node Exporter container on each ZDM Proxy instance
   hosts: proxies
-  become: yes
+  #become: yes
   vars_files:
     - vars/zdm_playbook_internal_config.yml
     - vars/zdm_monitoring_config.yml
@@ -41,7 +41,7 @@
 
 - name: Install Docker on the monitoring server
   hosts: monitoring
-  become: yes
+  #become: yes
   vars_files:
     - vars/zdm_playbook_internal_config.yml
 
@@ -64,7 +64,7 @@
 
 - name: Clean up any existing ZDM monitoring containers (except for named volume containing metrics data)
   hosts: monitoring
-  become: yes
+  #become: yes
   vars_files:
     - vars/zdm_monitoring_config.yml
     - vars/zdm_playbook_internal_config.yml
@@ -93,7 +93,7 @@
 
 - name: Prepare all ZDM Prometheus configuration on the monitoring host
   hosts: monitoring
-  become: yes
+  #become: yes
   vars_files:
     - vars/zdm_monitoring_config.yml
     - vars/zdm_proxy_advanced_config.yml
@@ -119,7 +119,7 @@
 
 - name: Create and start ZDM Prometheus container on the monitoring host
   hosts: monitoring
-  become: yes
+  #become: yes
   vars_files:
     - vars/zdm_monitoring_config.yml
     - vars/zdm_playbook_internal_config.yml
@@ -150,7 +150,7 @@
 
 - name: Prepare all ZDM Grafana configuration on the monitoring host
   hosts: monitoring
-  become: yes
+  #become: yes
   vars_files:
     - vars/zdm_monitoring_config.yml
     - vars/zdm_playbook_internal_config.yml
@@ -195,7 +195,7 @@
 
 - name: Create and start ZDM Grafana container on the monitoring host
   hosts: monitoring
-  become: yes
+  #become: yes
   vars_files:
     - vars/zdm_monitoring_config.yml
     - vars/zdm_playbook_internal_config.yml

--- a/ansible/deploy_zdm_monitoring.yml
+++ b/ansible/deploy_zdm_monitoring.yml
@@ -1,7 +1,7 @@
 ---
 - name: Deploy a Prometheus Node Exporter container on each ZDM Proxy instance
   hosts: proxies
-  #become: yes
+  become: yes
   vars_files:
     - vars/zdm_playbook_internal_config.yml
     - vars/zdm_monitoring_config.yml

--- a/ansible/deploy_zdm_monitoring.yml
+++ b/ansible/deploy_zdm_monitoring.yml
@@ -64,7 +64,6 @@
 
 - name: Clean up any existing ZDM monitoring containers (except for named volume containing metrics data)
   hosts: monitoring
-  #become: yes
   vars_files:
     - vars/zdm_monitoring_config.yml
     - vars/zdm_playbook_internal_config.yml
@@ -93,7 +92,6 @@
 
 - name: Prepare all ZDM Prometheus configuration on the monitoring host
   hosts: monitoring
-  #become: yes
   vars_files:
     - vars/zdm_monitoring_config.yml
     - vars/zdm_proxy_advanced_config.yml
@@ -119,7 +117,6 @@
 
 - name: Create and start ZDM Prometheus container on the monitoring host
   hosts: monitoring
-  #become: yes
   vars_files:
     - vars/zdm_monitoring_config.yml
     - vars/zdm_playbook_internal_config.yml
@@ -150,7 +147,6 @@
 
 - name: Prepare all ZDM Grafana configuration on the monitoring host
   hosts: monitoring
-  #become: yes
   vars_files:
     - vars/zdm_monitoring_config.yml
     - vars/zdm_playbook_internal_config.yml
@@ -195,7 +191,6 @@
 
 - name: Create and start ZDM Grafana container on the monitoring host
   hosts: monitoring
-  #become: yes
   vars_files:
     - vars/zdm_monitoring_config.yml
     - vars/zdm_playbook_internal_config.yml

--- a/ansible/vars/zdm_playbook_internal_config.yml
+++ b/ansible/vars/zdm_playbook_internal_config.yml
@@ -1,12 +1,13 @@
 ---
+# Rolling restarts
+pause_between_restarts_in_seconds: 10
 
+# Proxy
 zdm_proxy_user_name: ubuntu
 zdm_proxy_home_dir: /home/ubuntu
 
-zdm_proxy_config_fragments_dir_name: zdm_proxy_config_fragments
-
 zdm_proxy_shared_assets_dir_name: shared_assets
-
+zdm_proxy_config_fragments_dir_name: zdm_proxy_config_fragments
 zdm_proxy_mutable_config_fragment_file_name: zdm_proxy_mutable_config.env
 zdm_proxy_immutable_config_fragment_file_name: zdm_proxy_immutable_config.env
 zdm_proxy_environment_config_file_name: zdm_proxy_config.env
@@ -21,6 +22,7 @@ origin_tls_dest_dir_name: origin_tls
 target_tls_dest_dir_name: target_tls
 zdm_proxy_tls_dest_dir_name: proxy_tls
 
+# Monitoring
 monitoring_user_name: ubuntu
 monitoring_home_dir: /home/ubuntu
 
@@ -28,4 +30,5 @@ prometheus_config_dir_name: zdm_prometheus_config
 grafana_config_dir_name: zdm_grafana_config
 grafana_dashboards_dir_name: zdm_grafana_dashboards
 
-pause_between_restarts_in_seconds: 10
+# Log collection
+archived_log_dir_name: zdm_proxy_archived_logs

--- a/ansible/vars/zdm_playbook_internal_config.yml
+++ b/ansible/vars/zdm_playbook_internal_config.yml
@@ -29,3 +29,5 @@ grafana_config_dir_name: zdm_grafana_config
 grafana_dashboards_dir_name: zdm_grafana_dashboards
 
 pause_between_restarts_in_seconds: 10
+
+control_host_home_dir: /home/ubuntu

--- a/ansible/vars/zdm_playbook_internal_config.yml
+++ b/ansible/vars/zdm_playbook_internal_config.yml
@@ -29,5 +29,3 @@ grafana_config_dir_name: zdm_grafana_config
 grafana_dashboards_dir_name: zdm_grafana_dashboards
 
 pause_between_restarts_in_seconds: 10
-
-control_host_home_dir: /home/ubuntu

--- a/ansible/vars/zdm_playbook_internal_config.yml
+++ b/ansible/vars/zdm_playbook_internal_config.yml
@@ -32,3 +32,4 @@ grafana_dashboards_dir_name: zdm_grafana_dashboards
 
 # Log collection
 archived_log_dir_name: zdm_proxy_archived_logs
+tmp_log_dir_name: tmp_logs

--- a/ansible/vars/zdm_proxy_log_collection_config.yml
+++ b/ansible/vars/zdm_proxy_log_collection_config.yml
@@ -1,6 +1,0 @@
----
-# Directory, on the Ansible control host, where the zipped log archive should be placed.
-archived_log_dir_name: zdm_proxy_archived_logs
-
-# Temporary directory, one the Ansible control host, used while handling the log files. Will be removed at the end of the playbook execution.
-tmp_log_dir_name: tmp_logs

--- a/ansible/vars/zdm_proxy_log_collection_config.yml
+++ b/ansible/vars/zdm_proxy_log_collection_config.yml
@@ -1,13 +1,6 @@
 ---
-# Host on which the playbook is executed. Use localhost for execution on local machine, or monitoring for execution on jumphost.
-log_collection_playbook_host: monitoring
-
 # Directory, on the Ansible control host, where the zipped log archive should be placed.
-# If running the playbook on local machine, provide the desired absolute path (the directory will be created if it does not exist)
-# If running the playbook on the jumphost, the default value is fine
 archived_log_dir_name: zdm_proxy_archived_logs
 
 # Temporary directory, one the Ansible control host, used while handling the log files. Will be removed at the end of the playbook execution.
-# If running the playbook on local machine, provide the desired absolute path (the directory will be created if it does not exist)
-# If running the playbook on the jumphost, the default value is fine
 tmp_log_dir_name: tmp_logs

--- a/ansible/vars/zdm_proxy_log_collection_config.yml
+++ b/ansible/vars/zdm_proxy_log_collection_config.yml
@@ -10,7 +10,4 @@ archived_log_dir_name: zdm_proxy_archived_logs
 # Temporary directory, one the Ansible control host, used while handling the log files. Will be removed at the end of the playbook execution.
 # If running the playbook on local machine, provide the desired absolute path (the directory will be created if it does not exist)
 # If running the playbook on the jumphost, the default value is fine
-host_tmp_log_dir_name: host_tmp_logs
-
-
-container_tmp_log_dir_name: cont_tmp_logs
+tmp_log_dir_name: tmp_logs

--- a/ansible/vars/zdm_proxy_log_collection_config.yml
+++ b/ansible/vars/zdm_proxy_log_collection_config.yml
@@ -10,4 +10,7 @@ archived_log_dir_name: zdm_proxy_archived_logs
 # Temporary directory, one the Ansible control host, used while handling the log files. Will be removed at the end of the playbook execution.
 # If running the playbook on local machine, provide the desired absolute path (the directory will be created if it does not exist)
 # If running the playbook on the jumphost, the default value is fine
-tmp_log_dir_name: tmp_logs
+host_tmp_log_dir_name: host_tmp_logs
+
+
+container_tmp_log_dir_name: cont_tmp_logs


### PR DESCRIPTION
Collect logs playbook:
- ZDM Ansible image Dockerfile: moved installation of Ansible Galaxy community collection to after the creation of the ubuntu user so that it is installed under its home, as suggested by Wei.
- Changed `hosts` directive of two plays of the collect log playbook to `localhost` so that it all gets executed locally to the Ansible Control Host container. The previous version allowed to choose the execution host between local and jumphost (monitoring server), but with the containerisation of the control host this choice was obsolete and potentially error-prone.
- Removed harmless but unnecessary temp directory creation on proxy hosts.
- Moved the log collection config variables to the internal playbook config file and removed the log collection configuration file (this separation was no longer necessary).

Monitoring playbook:
- Removed unnecessary super user directive (`become: yes`) from several plays in the monitoring playbook