### PR TITLE
#42 Fix docker group

### DIFF
--- a/ansible/deploy_zdm_proxy.yml
+++ b/ansible/deploy_zdm_proxy.yml
@@ -6,8 +6,8 @@
     - vars/zdm_playbook_internal_config.yml
 
   tasks:
-    - name: Check if Docker is already installed
-      command: docker --version
+    - name: Check if Docker Engine is already installed
+      command: docker run hello-world
       register: docker_installed
       ignore_errors: yes
     - name: Install Docker if it is not yet present

--- a/ansible/deploy_zdm_proxy.yml
+++ b/ansible/deploy_zdm_proxy.yml
@@ -7,7 +7,7 @@
 
   tasks:
     - name: Check if Docker Engine is already installed
-      command: docker run hello-world
+      command: docker run --name test hello-world
       register: docker_installed
       ignore_errors: yes
     - name: Install Docker if it is not yet present
@@ -41,6 +41,10 @@
     - name: Remove environment configuration file if it already exists
       file:
         path: "{{ zdm_proxy_home_dir }}/{{ zdm_proxy_environment_config_file_name }}"
+        state: absent
+    - name: Clean up the test container if it exists
+      docker_container:
+        name: "test"
         state: absent
     - name: Remove any existing proxy container
       docker_container:

--- a/ansible/tasks/install_docker.yml
+++ b/ansible/tasks/install_docker.yml
@@ -13,9 +13,6 @@
     repo: deb https://download.docker.com/linux/ubuntu bionic stable
     state: present
 
-- name: Update apt and install docker-ce
-  apt: update_cache=yes name=docker-ce state=latest
-
 # sudo groupadd docker
 - name: Create "docker" group
   group:
@@ -26,8 +23,11 @@
 - name: Add OS user to "docker" group
   user:
     name: "{{ user_name }}"
-    group: "docker"
+    groups: "docker"
     append: yes
+
+- name: Update apt and install docker-ce
+  apt: update_cache=yes name=docker-ce state=latest
 
 # Resets the ssh connection to activate the "docker" group change
 # Equivalent to logging out and in again


### PR DESCRIPTION
I've tested the change on a brand-new set of proxy hosts, as well as 3-nodes that were installed with proxy containers before, and after using the following commands to remove the existing docker installation:
```
sudo systemctl stop docker.service docker.socket; sudo apt -y remove docker-ce docker-ce-cli containerd.io
```
In both situations, I'm able to see ubuntu user is keeping the primary group as ubuntu, while docker is added as an additional group.

Note, I also updated the docker detection script to use docker on the host to run a hello-world test container. The previous approach of using "docker --version" can only prove docker-ce-cli is installed, but if docker engine is not working, the previous approach will not be able to detect that.