### PR TITLE
Fix rolling restart playbook

### DIFF
--- a/ansible/rolling_restart_zdm_proxy.yml
+++ b/ansible/rolling_restart_zdm_proxy.yml
@@ -19,6 +19,7 @@
       docker_container:
         name: "{{ zdm_proxy_container_name }}"
         state: started
+        recreate: no
     - name: Wait for this ZDM proxy to come up
       uri:
         url: "http://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ metrics_port }}/health/readiness"

--- a/ansible/rolling_restart_zdm_proxy.yml
+++ b/ansible/rolling_restart_zdm_proxy.yml
@@ -11,7 +11,7 @@
 
   tasks:
     - name: Restart one ZDM proxy instance at a time
-      shell: docker restart zdm-proxy-container
+      shell: docker restart "{{ zdm_proxy_container_name }}"
     - name: Wait for this ZDM proxy to come up
       uri:
         url: "http://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ metrics_port }}/health/readiness"

--- a/ansible/rolling_restart_zdm_proxy.yml
+++ b/ansible/rolling_restart_zdm_proxy.yml
@@ -11,15 +11,13 @@
     - vars/zdm_proxy_cluster_config.yml
 
   tasks:
-    - name: Restart one ZDM proxy instance at a time
+    - name: Stop one ZDM proxy instance at a time
       docker_container:
         name: "{{ zdm_proxy_container_name }}"
-        env:
-          ZDM_ORIGIN_USERNAME: "{{ origin_username | default('') }}"
-          ZDM_ORIGIN_PASSWORD: "{{ origin_password | default('') }}"
-          ZDM_TARGET_USERNAME: "{{ target_username | default('') }}"
-          ZDM_TARGET_PASSWORD: "{{ target_password | default('') }}"
-        restart: yes
+        state: stopped
+    - name: Start that ZDM proxy instance
+      docker_container:
+        name: "{{ zdm_proxy_container_name }}"
         state: started
     - name: Wait for this ZDM proxy to come up
       uri:

--- a/ansible/rolling_restart_zdm_proxy.yml
+++ b/ansible/rolling_restart_zdm_proxy.yml
@@ -8,11 +8,17 @@
     - vars/zdm_proxy_container_config.yml
     - vars/zdm_proxy_advanced_config.yml
     - vars/zdm_playbook_internal_config.yml
+    - vars/zdm_proxy_cluster_config.yml
 
   tasks:
     - name: Restart one ZDM proxy instance at a time
       docker_container:
         name: "{{ zdm_proxy_container_name }}"
+        env:
+          ZDM_ORIGIN_USERNAME: "{{ origin_username | default('') }}"
+          ZDM_ORIGIN_PASSWORD: "{{ origin_password | default('') }}"
+          ZDM_TARGET_USERNAME: "{{ target_username | default('') }}"
+          ZDM_TARGET_PASSWORD: "{{ target_password | default('') }}"
         restart: yes
         state: started
     - name: Wait for this ZDM proxy to come up

--- a/ansible/rolling_restart_zdm_proxy.yml
+++ b/ansible/rolling_restart_zdm_proxy.yml
@@ -8,18 +8,10 @@
     - vars/zdm_proxy_container_config.yml
     - vars/zdm_proxy_advanced_config.yml
     - vars/zdm_playbook_internal_config.yml
-    - vars/zdm_proxy_cluster_config.yml
 
   tasks:
-    - name: Stop one ZDM proxy instance at a time
-      docker_container:
-        name: "{{ zdm_proxy_container_name }}"
-        state: stopped
-    - name: Start that ZDM proxy instance
-      docker_container:
-        name: "{{ zdm_proxy_container_name }}"
-        state: started
-        recreate: no
+    - name: Restart one ZDM proxy instance at a time
+      shell: docker restart zdm-proxy-container
     - name: Wait for this ZDM proxy to come up
       uri:
         url: "http://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ metrics_port }}/health/readiness"
@@ -31,6 +23,3 @@
     - pause:
         prompt: "Pause for {{ pause_between_restarts_in_seconds }} seconds after restarting this ZDM proxy instance"
         seconds: "{{ pause_between_restarts_in_seconds }}"
-
-
-

--- a/ansible/tasks/install_docker_ansible_module.yml
+++ b/ansible/tasks/install_docker_ansible_module.yml
@@ -13,3 +13,4 @@
 - name: Install Docker Module for Python
   pip:
     name: docker
+    version: 2.7.4

--- a/ansible/tasks/install_docker_ansible_module.yml
+++ b/ansible/tasks/install_docker_ansible_module.yml
@@ -13,4 +13,4 @@
 - name: Install Docker Module for Python
   pip:
     name: docker
-    version: 2.7.4
+    version: 2.7.0


### PR DESCRIPTION
This PR fixes a recent regression that appears to have been caused by a change in behaviour of the Ansible Docker module. This broke the `rolling_restart_zdm_proxy.yml` playbook (all other playbooks were not affected).

Changes in this PR are:
- The rolling restart operation is now done by running the `docker restart` shell command, rather than using the Docker module.
- The Ansible Docker module version has been pinned to `2.7.0`, which is the latest version available through `pip` and compatible with the version of Ansible used by the automation.

No documentation changes are needed for this PR, as these are purely internal fixes that do not change the user interaction.
