### PR TITLE
[Terraform] Add optional Owner tag to infrastructure resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ To launch the Terraform automation, you can use one of the two bash scripts prov
 
 Both scripts require some configuration, in the form of required and optional variables at the top of each script. You will need to uncomment and populate these variables as appropriate. If you are using the option with peering, the peering connection will be created automatically, but you may still need to make changes to the security groups of your cluster and / or client application instances to allow communication with the ZDM instances, depending on your specific configuration.
 
+An optional custom suffix can be specified, e.g. to distinguish infrastructure for different ZDM deployments within the same AWS account. In this case, the suffix is appended to the name of each resource (separated by a dash), and an Owner AWS tag set to the suffix value is assigned to each resource. This allows to easily see all infrastructure for a certain deployment by filtering by its Owner tag.
+
 When you execute the script, the Terraform output will be displayed and at the end you will see:
 * The variables with which the script has been executed.  If you need to tear down all the infrastructure provisioned, you can go to the directory of the root module that you used and execute the command `terraform destroy` followed by all these variables (these are also persisted to file `tf_latest_vars.txt` in this directory).
 * The output of the automation, with the IP addresses of the instances that were provisioned and the ZDM VPC ID. This output is also saved to file `zdm_output.txt` in the `zdm-proxy-automation` base directory.

--- a/orchestration-scripts/run_terraform_zdm.sh
+++ b/orchestration-scripts/run_terraform_zdm.sh
@@ -50,7 +50,7 @@ zdm_vpc_cidr_prefix="172.18"
 
 # OPTIONAL: Suffix to append to the name of each resource that is being provisioned.
 # This can be useful to distinguish the resources of different deployments in the same region.
-# Defaults to an empty string.
+# Defaults to an empty string. A dash will be automatically added in front of it as this suffix is appended to the resource names.
 #custom_name_suffix=
 
 # OPTIONAL: zdm_linux_distro to be used for both proxy and monitoring instances.
@@ -159,7 +159,10 @@ build_terraform_var_str () {
   fi
 
   if [ -n "${custom_name_suffix}" ]; then
-    terraform_vars+="-var \"custom_name_suffix=${custom_name_suffix}\" "
+    # owner is simply set to the value used as a suffix, if specified
+    terraform_vars+="-var \"owner=${custom_name_suffix}\" "
+    # prepend a dash to separate from the main name
+    terraform_vars+="-var \"custom_name_suffix=-${custom_name_suffix}\" "
   fi
 
   if [ -n "${zdm_linux_distro}" ]; then

--- a/orchestration-scripts/run_terraform_zdm_no_peering.sh
+++ b/orchestration-scripts/run_terraform_zdm_no_peering.sh
@@ -38,7 +38,7 @@ zdm_vpc_cidr_prefix="172.18"
 
 # OPTIONAL: Suffix to append to the name of each resource that is being provisioned.
 # This can be useful to distinguish the resources of different deployments in the same region.
-# Defaults to an empty string.
+# Defaults to an empty string. A dash will be automatically added in front of it as this suffix is appended to the resource names.
 #custom_name_suffix=
 
 # OPTIONAL: zdm_linux_distro to be used for both proxy and monitoring instances.
@@ -136,7 +136,10 @@ build_terraform_var_str () {
   fi
 
   if [ -n "${custom_name_suffix}" ]; then
-    terraform_vars+="-var \"custom_name_suffix=${custom_name_suffix}\" "
+    # owner is simply set to the value used as a suffix, if specified
+    terraform_vars+="-var \"owner=${custom_name_suffix}\" "
+    # prepend a dash to separate from the main name
+    terraform_vars+="-var \"custom_name_suffix=-${custom_name_suffix}\" "
   fi
 
   if [ -n "${zdm_linux_distro}" ]; then

--- a/terraform/aws/no-peering-deployment-root-aws/main.tf
+++ b/terraform/aws/no-peering-deployment-root-aws/main.tf
@@ -19,6 +19,7 @@ module "zdm_proxy_networking" {
   source = "../submodules-aws/networking-aws"
 
   custom_name_suffix = var.custom_name_suffix
+  owner = var.owner
   zdm_aws_profile = var.zdm_aws_profile
   zdm_aws_region = var.zdm_aws_region
 
@@ -33,6 +34,7 @@ module "zdm_instances" {
   source = "../submodules-aws/instances-aws"
 
   custom_name_suffix = var.custom_name_suffix
+  owner = var.owner
   zdm_linux_distro = var.zdm_linux_distro
   zdm_aws_profile = var.zdm_aws_profile
   zdm_aws_region = var.zdm_aws_region

--- a/terraform/aws/no-peering-deployment-root-aws/variables.tf
+++ b/terraform/aws/no-peering-deployment-root-aws/variables.tf
@@ -40,6 +40,11 @@ variable "custom_name_suffix" {
   default = ""
 }
 
+variable "owner" {
+  description = "Owner of this set of infrastructure resources"
+  default = ""
+}
+
 variable "zdm_linux_distro" {
   default = "jammy"
 

--- a/terraform/aws/self-contained-deployment-root-aws/main.tf
+++ b/terraform/aws/self-contained-deployment-root-aws/main.tf
@@ -34,6 +34,7 @@ module "vpc_peering" {
   source = "../submodules-aws/vpc-peering-aws"
 
   custom_name_suffix = var.custom_name_suffix
+  owner = var.owner
   zdm_aws_region = var.zdm_aws_region
   zdm_aws_profile = var.zdm_aws_profile
   // if no user AWS profile was specified, default the user AWS profile to the ZDM AWS profile

--- a/terraform/aws/self-contained-deployment-root-aws/main.tf
+++ b/terraform/aws/self-contained-deployment-root-aws/main.tf
@@ -34,7 +34,6 @@ module "vpc_peering" {
   source = "../submodules-aws/vpc-peering-aws"
 
   custom_name_suffix = var.custom_name_suffix
-  owner = var.owner
   zdm_aws_region = var.zdm_aws_region
   zdm_aws_profile = var.zdm_aws_profile
   // if no user AWS profile was specified, default the user AWS profile to the ZDM AWS profile

--- a/terraform/aws/self-contained-deployment-root-aws/main.tf
+++ b/terraform/aws/self-contained-deployment-root-aws/main.tf
@@ -19,6 +19,7 @@ module "zdm_proxy_networking" {
   source = "../submodules-aws/networking-aws"
 
   custom_name_suffix = var.custom_name_suffix
+  owner = var.owner
   zdm_aws_profile = var.zdm_aws_profile
   zdm_aws_region = var.zdm_aws_region
 
@@ -33,6 +34,7 @@ module "vpc_peering" {
   source = "../submodules-aws/vpc-peering-aws"
 
   custom_name_suffix = var.custom_name_suffix
+  owner = var.owner
   zdm_aws_region = var.zdm_aws_region
   zdm_aws_profile = var.zdm_aws_profile
   // if no user AWS profile was specified, default the user AWS profile to the ZDM AWS profile
@@ -52,6 +54,7 @@ module "zdm_instances" {
   zdm_public_key_local_path = var.zdm_public_key_local_path
   zdm_keypair_name = var.zdm_keypair_name
   custom_name_suffix = var.custom_name_suffix
+  owner = var.owner
   zdm_linux_distro = var.zdm_linux_distro
 
   zdm_proxy_instance_count = var.zdm_proxy_instance_count

--- a/terraform/aws/self-contained-deployment-root-aws/variables.tf
+++ b/terraform/aws/self-contained-deployment-root-aws/variables.tf
@@ -57,6 +57,11 @@ variable "custom_name_suffix" {
   default = ""
 }
 
+variable "owner" {
+  description = "Owner of this set of infrastructure resources"
+  default = ""
+}
+
 variable "zdm_linux_distro" {
   default = "jammy"
 

--- a/terraform/aws/submodules-aws/instances-aws/main.tf
+++ b/terraform/aws/submodules-aws/instances-aws/main.tf
@@ -108,7 +108,7 @@ resource "aws_instance" "zdm_monitoring" {
 resource "aws_eip" "zdm_monitoring_eip" {
   vpc      = true
   tags = {
-    Name = "ZDM_Monitoring_EIP${var.custom_name_suffix}"
+    Name = "ZDM_Jumphost_EIP${var.custom_name_suffix}"
     Owner = var.owner
   }
 }

--- a/terraform/aws/submodules-aws/instances-aws/main.tf
+++ b/terraform/aws/submodules-aws/instances-aws/main.tf
@@ -100,7 +100,7 @@ resource "aws_instance" "zdm_monitoring" {
   }
 
   tags = {
-    Name = "ZDM_Monitoring${var.custom_name_suffix}"
+    Name = "ZDM_Jumphost${var.custom_name_suffix}"
     Owner = var.owner
   }
 }

--- a/terraform/aws/submodules-aws/instances-aws/variables.tf
+++ b/terraform/aws/submodules-aws/instances-aws/variables.tf
@@ -30,6 +30,8 @@ variable "public_subnet_id" {
 
 variable "custom_name_suffix" {}
 
+variable "owner" {}
+
 variable "zdm_linux_distro" {
   default = "jammy"
 

--- a/terraform/aws/submodules-aws/networking-aws/main.tf
+++ b/terraform/aws/submodules-aws/networking-aws/main.tf
@@ -21,6 +21,7 @@ resource "aws_vpc" "zdm_vpc" {
 
   tags = {
     Name = "zdm_vpc${var.custom_name_suffix}"
+    Owner = var.owner
   }
 }
 
@@ -39,6 +40,7 @@ resource "aws_subnet" "private_subnets" {
   map_public_ip_on_launch = false
   tags = {
     Name = "private_subnet_${data.aws_availability_zones.available.names[count.index]}${var.custom_name_suffix}"
+    Owner = var.owner
   }
 }
 
@@ -51,6 +53,7 @@ resource "aws_route_table" "private_subnet_rt" {
   vpc_id = aws_vpc.zdm_vpc.id
   tags = {
     Name = "private_subnet_rt${var.custom_name_suffix}"
+    Owner = var.owner
   }
 }
 
@@ -107,6 +110,7 @@ resource "aws_security_group" "private_instance_sg" {
 
   tags = {
     Name = "private_instance_sg${var.custom_name_suffix}"
+    Owner = var.owner
   }
 }
 
@@ -119,6 +123,7 @@ resource "aws_subnet" "public_subnet" {
   vpc_id = aws_vpc.zdm_vpc.id
   tags = {
     Name = "public_subnet_${data.aws_availability_zones.available.names[0]}${var.custom_name_suffix}"
+    Owner = var.owner
   }
 }
 
@@ -131,6 +136,7 @@ resource "aws_nat_gateway" "nat_gateway" {
   subnet_id = aws_subnet.public_subnet.id
   tags = {
     Name = "zdm_nat_gateway${var.custom_name_suffix}"
+    Owner = var.owner
   }
 }
 
@@ -151,6 +157,7 @@ resource "aws_default_route_table" "default_route_table_for_vpc" {
 
   tags = {
     Name = "default_route_table"
+    Owner = var.owner
   }
 }
 
@@ -161,6 +168,7 @@ resource "aws_internet_gateway" "internet_gateway" {
   vpc_id = aws_vpc.zdm_vpc.id
   tags = {
     Name = "zdm_internet_gateway${var.custom_name_suffix}"
+    Owner = var.owner
   }
 }
 
@@ -171,6 +179,7 @@ resource "aws_route_table" "internet_gateway_rt" {
   vpc_id = aws_vpc.zdm_vpc.id
   tags = {
     Name = "zdm_internet_gateway_rt${var.custom_name_suffix}"
+    Owner = var.owner
   }
 }
 
@@ -233,6 +242,7 @@ resource "aws_security_group" "public_instance_sg" {
   }
 
   tags = {
-      Name = "public_instance_sg${var.custom_name_suffix}"
+    Name = "public_instance_sg${var.custom_name_suffix}"
+    Owner = var.owner
   }
 }

--- a/terraform/aws/submodules-aws/networking-aws/main.tf
+++ b/terraform/aws/submodules-aws/networking-aws/main.tf
@@ -142,6 +142,10 @@ resource "aws_nat_gateway" "nat_gateway" {
 
 resource "aws_eip" "nat_gateway_eip" {
   vpc      = true
+  tags = {
+    Name = "zdm_nat_gateway_eip${var.custom_name_suffix}"
+    Owner = var.owner
+  }
 }
 
 ##################################################################################

--- a/terraform/aws/submodules-aws/networking-aws/main.tf
+++ b/terraform/aws/submodules-aws/networking-aws/main.tf
@@ -20,7 +20,7 @@ resource "aws_vpc" "zdm_vpc" {
   enable_dns_support = true
 
   tags = {
-    Name = "zdm_vpc${var.custom_name_suffix}"
+    Name = "ZDM_VPC${var.custom_name_suffix}"
     Owner = var.owner
   }
 }
@@ -39,7 +39,7 @@ resource "aws_subnet" "private_subnets" {
   availability_zone= data.aws_availability_zones.available.names[count.index]
   map_public_ip_on_launch = false
   tags = {
-    Name = "private_subnet_${data.aws_availability_zones.available.names[count.index]}${var.custom_name_suffix}"
+    Name = "ZDM_Private_Subnet_${data.aws_availability_zones.available.names[count.index]}${var.custom_name_suffix}"
     Owner = var.owner
   }
 }
@@ -52,7 +52,7 @@ resource "aws_subnet" "private_subnets" {
 resource "aws_route_table" "private_subnet_rt" {
   vpc_id = aws_vpc.zdm_vpc.id
   tags = {
-    Name = "private_subnet_rt${var.custom_name_suffix}"
+    Name = "ZDM_Private_Subnet_RT${var.custom_name_suffix}"
     Owner = var.owner
   }
 }
@@ -109,7 +109,7 @@ resource "aws_security_group" "private_instance_sg" {
   }
 
   tags = {
-    Name = "private_instance_sg${var.custom_name_suffix}"
+    Name = "ZDM_Private_Instance_SG${var.custom_name_suffix}"
     Owner = var.owner
   }
 }
@@ -122,7 +122,7 @@ resource "aws_subnet" "public_subnet" {
   cidr_block = cidrsubnet(aws_vpc.zdm_vpc.cidr_block, 8, 100 )
   vpc_id = aws_vpc.zdm_vpc.id
   tags = {
-    Name = "public_subnet_${data.aws_availability_zones.available.names[0]}${var.custom_name_suffix}"
+    Name = "ZDM_Public_Subnet_${data.aws_availability_zones.available.names[0]}${var.custom_name_suffix}"
     Owner = var.owner
   }
 }
@@ -135,7 +135,7 @@ resource "aws_nat_gateway" "nat_gateway" {
   allocation_id = aws_eip.nat_gateway_eip.id
   subnet_id = aws_subnet.public_subnet.id
   tags = {
-    Name = "zdm_nat_gateway${var.custom_name_suffix}"
+    Name = "ZDM_NAT_Gateway${var.custom_name_suffix}"
     Owner = var.owner
   }
 }
@@ -143,7 +143,7 @@ resource "aws_nat_gateway" "nat_gateway" {
 resource "aws_eip" "nat_gateway_eip" {
   vpc      = true
   tags = {
-    Name = "zdm_nat_gateway_eip${var.custom_name_suffix}"
+    Name = "ZDM_NAT_Gateway_EIP${var.custom_name_suffix}"
     Owner = var.owner
   }
 }
@@ -171,7 +171,7 @@ resource "aws_default_route_table" "default_route_table_for_vpc" {
 resource "aws_internet_gateway" "internet_gateway" {
   vpc_id = aws_vpc.zdm_vpc.id
   tags = {
-    Name = "zdm_internet_gateway${var.custom_name_suffix}"
+    Name = "ZDM_Internet_Gateway${var.custom_name_suffix}"
     Owner = var.owner
   }
 }
@@ -182,7 +182,7 @@ resource "aws_internet_gateway" "internet_gateway" {
 resource "aws_route_table" "internet_gateway_rt" {
   vpc_id = aws_vpc.zdm_vpc.id
   tags = {
-    Name = "zdm_internet_gateway_rt${var.custom_name_suffix}"
+    Name = "ZDM_Internet_Gateway_RT${var.custom_name_suffix}"
     Owner = var.owner
   }
 }
@@ -246,7 +246,7 @@ resource "aws_security_group" "public_instance_sg" {
   }
 
   tags = {
-    Name = "public_instance_sg${var.custom_name_suffix}"
+    Name = "ZDM_Public_Instance_SG${var.custom_name_suffix}"
     Owner = var.owner
   }
 }

--- a/terraform/aws/submodules-aws/networking-aws/variables.tf
+++ b/terraform/aws/submodules-aws/networking-aws/variables.tf
@@ -17,3 +17,5 @@ variable "allowed_outbound_ip_ranges" {
 }
 
 variable "custom_name_suffix" {}
+
+variable "owner" {}

--- a/terraform/aws/submodules-aws/vpc-peering-aws/main.tf
+++ b/terraform/aws/submodules-aws/vpc-peering-aws/main.tf
@@ -133,7 +133,7 @@ resource "aws_security_group" "zdm_allow_traffic_from_peering_sg" {
   }
 
   tags = {
-    Name = "ZDM_Allow_Traffic_From_ZDMPeering_SG"
+    Name = "ZDM_Allow_Traffic_From_ZDMPeering_SG${var.custom_name_suffix}"
     Owner = var.owner
   }
 
@@ -156,7 +156,7 @@ resource "aws_security_group" "user_allow_traffic_from_peering_sg" {
   // Not adding the default egress rule here to avoid interfering with other restrictive egress rules that the user may have set
 
   tags = {
-    Name = "User_Allow_Traffic_From_ZDMPeering_SG"
+    Name = "User_Allow_Traffic_From_ZDMPeering_SG${var.custom_name_suffix}"
     Owner = var.owner
   }
 

--- a/terraform/aws/submodules-aws/vpc-peering-aws/main.tf
+++ b/terraform/aws/submodules-aws/vpc-peering-aws/main.tf
@@ -133,6 +133,7 @@ resource "aws_security_group" "zdm_allow_traffic_from_peering_sg" {
   }
 
   tags = {
+    Name = "ZDM_Allow_Traffic_From_ZDMPeering_SG"
     Owner = var.owner
   }
 
@@ -155,6 +156,7 @@ resource "aws_security_group" "user_allow_traffic_from_peering_sg" {
   // Not adding the default egress rule here to avoid interfering with other restrictive egress rules that the user may have set
 
   tags = {
+    Name = "User_Allow_Traffic_From_ZDMPeering_SG"
     Owner = var.owner
   }
 

--- a/terraform/aws/submodules-aws/vpc-peering-aws/main.tf
+++ b/terraform/aws/submodules-aws/vpc-peering-aws/main.tf
@@ -37,6 +37,7 @@ resource "aws_vpc_peering_connection" "peering_request" {
 
   tags = {
     Side = "ZDM (Requester)"
+    Owner = var.owner
   }
 }
 
@@ -49,6 +50,7 @@ resource "aws_vpc_peering_connection_accepter" "peering_acceptance" {
 
   tags = {
     Side = "User (Accepter)"
+    Owner = var.owner
   }
 }
 
@@ -129,6 +131,11 @@ resource "aws_security_group" "zdm_allow_traffic_from_peering_sg" {
     protocol = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
+
+  tags = {
+    Owner = var.owner
+  }
+
 }
 
 resource "aws_security_group" "user_allow_traffic_from_peering_sg" {
@@ -146,5 +153,9 @@ resource "aws_security_group" "user_allow_traffic_from_peering_sg" {
   }
 
   // Not adding the default egress rule here to avoid interfering with other restrictive egress rules that the user may have set
+
+  tags = {
+    Owner = var.owner
+  }
 
 }

--- a/terraform/aws/submodules-aws/vpc-peering-aws/variables.tf
+++ b/terraform/aws/submodules-aws/vpc-peering-aws/variables.tf
@@ -18,3 +18,5 @@ variable "zdm_aws_region" {}
 
 variable "custom_name_suffix" {}
 
+variable "owner" {}
+


### PR DESCRIPTION
When creating ZDM infrastructure in AWS using the Terraform automation for multiple deployments, it may be difficult to distinguish the different sets of infrastructure for each deployment. The custom suffix appended to the name of the resources helped with this, but filtering was still quite cumbersome.

To make things easier, an Owner tag is now automatically assigned to each provisioned resource when the user specifies a custom suffix.

Here is how it works:
- The user specifies `custom_name_suffix` in the `run_terraform_zdm.sh` script (or the alternative version without built-in peering).
- A variable called `custom_name_suffix` is passed to Terraform, prepended with a dash. This variable will be appended to the name of each resource.
- A variable called `owner` is passed to Terraform, set to the same value as `custom_name_suffix` but without prepending a dash. This will be set as an AWS tag called Owner.

The user can then see all the resources for a certain deployment by filtering by Owner.

If `custom_name_suffix` is left empty, no suffix is appended and the Owner tag is left empty.